### PR TITLE
Bugfix

### DIFF
--- a/WhereAmIAgain/DTRDisplay.cs
+++ b/WhereAmIAgain/DTRDisplay.cs
@@ -97,6 +97,7 @@ public unsafe class DtrDisplay : IDisposable
             }
             
             dtrEntry.Text = new SeStringBuilder().AddText(filteredString).BuiltString;
+            locationChanged = false;
         }
         catch(FormatException)
         {

--- a/WhereAmIAgain/WhereAmIAgain.csproj
+++ b/WhereAmIAgain/WhereAmIAgain.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Authors></Authors>
     <Company></Company>
-	<AssemblyVersion>0.0.1.0</AssemblyVersion>
+	<AssemblyVersion>0.0.1.1</AssemblyVersion>
     <Description>Shows what zone/region/territory you are in next to the server info.</Description>
     <Copyright></Copyright>
     <PackageProjectUrl>https://github.com/cassandra308/WhereAmIAgain</PackageProjectUrl>


### PR DESCRIPTION
Forgot to unset `location changed` variable in UpdateDtrText function.
This was causing the update text function to run every frame, not just when an update is needed.

Increased version number to 0.0.1.1

Reduces Framework time from 0.0125ms to 0.0016ms per frame as originally intended.