### PR TITLE
Adds less greedy symbol filtering

### DIFF
--- a/WhereAmIAgain/DTRDisplay.cs
+++ b/WhereAmIAgain/DTRDisplay.cs
@@ -101,7 +101,7 @@ public unsafe class DtrDisplay : IDisposable
                 formattedString += GetCharacterForInstanceNumber(GetInstanceNumber());
             }
 
-            formattedString = Config.FormatString[..preTextEnd] + formattedString + Config.FormatString[..postTextStart];
+            formattedString = Config.FormatString[..preTextEnd] + formattedString + Config.FormatString[postTextStart..];
         }
         catch(FormatException)
         {

--- a/WhereAmIAgain/DTRDisplay.cs
+++ b/WhereAmIAgain/DTRDisplay.cs
@@ -81,8 +81,8 @@ public unsafe class DtrDisplay : IDisposable
 
     public void UpdateDtrText()
     {
-        var preTextEnd = Config.FormatString.IndexOf("{");
-        var postTextStart = Config.FormatString.LastIndexOf("}") + 1;
+        var preTextEnd = Config.FormatString.IndexOf('{');
+        var postTextStart = Config.FormatString.LastIndexOf('}') + 1;
         var formattedString = Config.FormatString;
         
         try
@@ -107,7 +107,8 @@ public unsafe class DtrDisplay : IDisposable
         {
             // Ignore format exceptions, because we warn the user in the config window if they are missing a format symbol 
         }
-        catch(ArgumentOutOfRangeException) {
+        catch(ArgumentOutOfRangeException)
+        {
             // Ignore range exceptions
         }
         


### PR DESCRIPTION
Filters (or at least attempts to) only the portion of the text containing the section to format. This should hopefully reduce unexpected behavior for users.

While this will allow users to add in their own server info separators, which is out of scope of this plugin, this change is intended instead to allow for more pretty formatting options. Like adding a map icon symbol in front of the text, a la Orchestrion, for example.